### PR TITLE
add tinc_extra_options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -230,3 +230,8 @@ tinc_host_port: 655
 # purpose.
 tinc_scripts: {}
 
+# .. envvar:: tinc_extra_options
+#
+# String with extra options to be passed to tincd in the 
+# /etc/default/tinc config file
+tinc_extra_options: ''


### PR DESCRIPTION
String with extra options to be passed to tincd in the  /etc/default/tinc config file
