### PR TITLE
Fix handling of lists in tinc host config.

### DIFF
--- a/templates/etc/tinc/network/hosts/hostname.j2
+++ b/templates/etc/tinc/network/hosts/hostname.j2
@@ -9,7 +9,7 @@
 {{ key }} = {{ value }}
 {% else %}
 {% for element in value %}
-{{ key }} = {{ value }}
+{{ key }} = {{ element }}
 {% endfor %}
 {% endif %}
 {% set _ = tinc_tpl_host_keys_seen.append(key) %}


### PR DESCRIPTION
When trying to apply multiple routed Subnets this was causing invalid
configurtion to be created.
