### PR TITLE
Rewrite of the 'debops.tinc' role

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,33 @@
 Changelog
 =========
 
+v0.2.0
+------
+
+*Released: 2016-02-22*
+
+- Rewrite of the ``debops.tinc`` role.
+
+  The role now supports management of multiple Tinc VPNs at the same time. By
+  default a ``mesh0`` network is estabilished, which uses the Switch mode and
+  DHCP to manage network configuration.
+
+  The new role ddoesn't use ``ifupdown`` configuration to manage the network
+  interfaces, instead custom ``tinc-up`` and ``tinc-down`` scripts take care of
+  setting up and tearing down the virtual Ethernet interface used by the VPN.
+
+  If ``systemd`` is detected on a host, role installs custom service units that
+  allow to manage each Tinc VPN separately from the others. The role uses these
+  units as needed to start/stop/restart the daemons.
+
+  Configuration for ``debops.etc_services``, ``debops.ferm`` and
+  ``debops.secret`` Ansible roles is generated dynamically by custom templates.
+  This requires a customized Ansible playbook (see the documentation).
+
+  Public RSA host keys are not distributed using YAML text blocks. Instead,
+  ``debops.secret`` role manages as set of directories which can be used to
+  deploy public keys to the hosts in the mesh. [drybjed]
+
 v0.1.1
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,17 +9,17 @@
 #   Network configuration
 # -------------------------
 
-# .. envvar:: tinc_networks
+# .. envvar:: tinc__networks
 #
-# List of Tinc Virtual Private Networks to configure. See :ref:`tinc_networks`
+# List of Tinc Virtual Private Networks to configure. See :ref:`tinc__networks`
 # for more details.
-tinc_networks: []
+tinc__networks: []
 
 
-# .. envvar:: tinc_default_networks
+# .. envvar:: tinc__default_networks
 #
 # List of default networks which are created by the ``debops.tinc`` role.
-tinc_default_networks: [ '{{ tinc_network_mesh0 }}' ]
+tinc__default_networks: [ '{{ tinc__network_mesh0 }}' ]
 
 
 # --------------------------------------
@@ -31,39 +31,39 @@ tinc_default_networks: [ '{{ tinc_network_mesh0 }}' ]
 # a bridge to which the ``tun0`` interface will be connected; on that bridge
 # you should configure DHCP and DNS server to provide interface configuration.
 
-# .. envvar:: tinc_network_mesh0
+# .. envvar:: tinc__network_mesh0
 #
 # The dictionary variable which defines the ``mesh0`` network. See
-# :ref:`tinc_networks` for more details about available options. Some of the
+# :ref:`tinc__networks` for more details about available options. Some of the
 # configuration parameters are exposed in their own default variables to make
 # simple config changes easier.
-tinc_network_mesh0:
+tinc__network_mesh0:
   name: 'mesh0'
-  interface: '{{ tinc_interface_mesh0 }}'
-  hwaddr: '{{ tinc_hwaddr_mesh0 }}'
-  bridge: '{{ tinc_bridge_mesh0 }}'
-  link_type: '{{ tinc_link_type_mesh0 }}'
-  boot: '{{ tinc_boot_mesh0 }}'
+  interface: '{{ tinc__interface_mesh0 }}'
+  hwaddr: '{{ tinc__hwaddr_mesh0 }}'
+  bridge: '{{ tinc__bridge_mesh0 }}'
+  link_type: '{{ tinc__link_type_mesh0 }}'
+  boot: '{{ tinc__boot_mesh0 }}'
   port: '655'
   mlock: True
   chroot: True
-  allow: '{{ tinc_allow_mesh0 }}'
-  user: '{{ tinc_user }}'
+  allow: '{{ tinc__allow_mesh0 }}'
+  user: '{{ tinc__user }}'
   tinc_options:
     Mode: 'switch'
     DeviceType: 'tap'
     Cipher: 'aes-256-cbc'
     Digest: 'SHA512'
-    ConnectTo: '{{ tinc_connect_to_mesh0 }}'
+    ConnectTo: '{{ tinc__connect_to_mesh0 }}'
 
 
-# .. envvar:: tinc_interface_mesh0
+# .. envvar:: tinc__interface_mesh0
 #
 # Name of the network interface to use for the Tinc ``mesh0`` VPN.
-tinc_interface_mesh0: 'tap-mesh0'
+tinc__interface_mesh0: 'tap-mesh0'
 
 
-# .. envvar:: tinc_link_type_mesh0
+# .. envvar:: tinc__link_type_mesh0
 #
 # Link type to set for the Tinc ``mesh0`` VPN. If empty, ``debops.tinc``
 # defaults to a standalone network interface with ``dhclient`` requesting
@@ -73,47 +73,47 @@ tinc_interface_mesh0: 'tap-mesh0'
 #   optionally attached to a network bridge. This should usually be done just
 #   on 1 host in the mesh to provide DHCP/DNS services.
 #
-tinc_link_type_mesh0: ''
+tinc__link_type_mesh0: ''
 
 
-# .. envvar:: tinc_hwaddr_mesh0
+# .. envvar:: tinc__hwaddr_mesh0
 #
 # Specify the Media Access Control address of the Tinc ``mesh0`` interface. If
 # not specified, a randomized stable MAC address will be generated
 # automatically. Set the MAC address value to ``'*'`` to generate a random
 # hardware address.
-tinc_hwaddr_mesh0: ''
+tinc__hwaddr_mesh0: ''
 
 
-# .. envvar:: tinc_boot_mesh0
+# .. envvar:: tinc__boot_mesh0
 #
 # Specify if the Tinc ``mesh0`` network should be started at boot.
-tinc_boot_mesh0: True
+tinc__boot_mesh0: True
 
 
-# .. envvar:: tinc_bridge_mesh0
+# .. envvar:: tinc__bridge_mesh0
 #
 # Name of the bridge to connect the interface of the Tinc ``mesh0`` VPN. This
 # should be set on a host that provides the DHCP and DNS services for the mesh.
-tinc_bridge_mesh0: ''
+tinc__bridge_mesh0: ''
 
 
-# .. envvar:: tinc_allow_mesh0
+# .. envvar:: tinc__allow_mesh0
 #
 # List of IP addresses or CIDR subnets which will be allowed to connect to the
 # Tinc ``mesh0`` VPN port (655) through the firewall. If this list is empty,
 # any IP address can connect.
-tinc_allow_mesh0: []
+tinc__allow_mesh0: []
 
 
-# .. envvar:: tinc_connect_to_mesh0
+# .. envvar:: tinc__connect_to_mesh0
 #
 # List of hosts specified as the ``ConnectTo`` option in the Tinc configuration
 # file of the ``mesh0`` network.
-tinc_connect_to_mesh0: '{{ tinc_inventory_hosts_mesh0 + tinc_external_hosts_mesh0 }}'
+tinc__connect_to_mesh0: '{{ tinc__inventory_hosts_mesh0 + tinc__external_hosts_mesh0 }}'
 
 
-# .. envvar:: tinc_inventory_hosts_mesh0
+# .. envvar:: tinc__inventory_hosts_mesh0
 #
 # List of other hosts in the Ansible inventory that are participating in the
 # ``mesh0`` network besides the current one. They will be listed in the
@@ -121,40 +121,40 @@ tinc_connect_to_mesh0: '{{ tinc_inventory_hosts_mesh0 + tinc_external_hosts_mesh
 # IP address. If not, you might want to specify the list of hosts to connect to
 # manually, otherwise Tinc will try and connect to the unreachable hosts all
 # the time.
-tinc_inventory_hosts_mesh0: '{{ (groups.debops_service_tinc_mesh0
-                                   if groups.debops_service_tinc_mesh0|d()
-                                   else []) | difference([ tinc_hostname ]) }}'
+tinc__inventory_hosts_mesh0: '{{ (groups.debops_service_tinc_mesh0
+                                  if groups.debops_service_tinc_mesh0|d()
+                                  else []) | difference([ tinc__hostname ]) }}'
 
 
-# .. envvar:: tinc_external_hosts_mesh0
+# .. envvar:: tinc__external_hosts_mesh0
 #
 # List of hosts to connect to which are not in the Ansible inventory. You
 # should provide the corresponding public key files through the directories in
 # ``secret/`` directory.
-tinc_external_hosts_mesh0: []
+tinc__external_hosts_mesh0: []
 
 
 # ----------------
 #   APT packages
 # ----------------
 
-# .. envvar:: tinc_base_packages
+# .. envvar:: tinc__base_packages
 #
 # List of APT packages to install for ``tinc`` support.
-tinc_base_packages: [ 'tinc' ]
+tinc__base_packages: [ 'tinc' ]
 
 
-# .. envvar:: tinc_packages
+# .. envvar:: tinc__packages
 #
 # List of additional APT packages to install during ``tinc`` configuration.
-tinc_packages: []
+tinc__packages: []
 
 
 # --------------------------------
 #   Ansible inventory parameters
 # --------------------------------
 
-# .. envvar:: tinc_inventory_groups
+# .. envvar:: tinc__inventory_groups
 #
 # List of Ansible inventory groups which are used by ``debops.tinc`` role to
 # manage separate ``tinc`` networks. Each group will have corresponding
@@ -162,127 +162,127 @@ tinc_packages: []
 #
 # The default Ansible group ``debops_service_tinc_mesh0`` specifies hosts that
 # are participating in the ``mesh0`` VPN.
-tinc_inventory_groups: [ 'debops_service_tinc_mesh0' ]
+tinc__inventory_groups: [ 'debops_service_tinc_mesh0' ]
 
 
-# .. envvar:: tinc_inventory_hosts
+# .. envvar:: tinc__inventory_hosts
 #
 # This list defines what hosts in Ansible inventory participate in a Tinc VPN.
 # They will have their own directories in ``secret/`` store on Ansible
 # Controller used to distribute public host keys.
-tinc_inventory_hosts: '{{ groups.debops_service_tinc
-                          if groups.debops_service_tinc|d()
-                          else [] }}'
+tinc__inventory_hosts: '{{ groups.debops_service_tinc
+                           if groups.debops_service_tinc|d()
+                           else [] }}'
 
 
-# .. envvar:: tinc_hostname
+# .. envvar:: tinc__hostname
 #
 # Name of this node used in configuration files thruought the mesh. Don't
 # change this unless you know what you are doing.
-tinc_hostname: '{{ inventory_hostname_short }}'
+tinc__hostname: '{{ inventory_hostname_short }}'
 
 
 # ---------------------------
 #   Application environment
 # ---------------------------
 
-# .. envvar:: tinc_user
+# .. envvar:: tinc__user
 #
 # System user account which is used to run ``tincd``.
-tinc_user: 'tinc-vpn'
+tinc__user: 'tinc-vpn'
 
 
-# .. envvar:: tinc_group
+# .. envvar:: tinc__group
 #
 # System group which is used to access ``tincd`` configuration files.
-tinc_group: 'tinc-vpn'
+tinc__group: 'tinc-vpn'
 
 
-# .. envvar:: tinc_home
+# .. envvar:: tinc__home
 #
 # Home directory of the ``tincd`` user.
-tinc_home: '/etc/tinc'
+tinc__home: '/etc/tinc'
 
 
-# .. envvar:: tinc_ulimit_options
+# .. envvar:: tinc__ulimit_options
 #
 # List of options passed to ``ulimit`` command before starting ``tincd``
 # processs. Set maximum size of address space locked into memory, in KB.
-tinc_ulimit_options: '-l {{ (1024 * 64) }}'
+tinc__ulimit_options: '-l {{ (1024 * 64) }}'
 
 
-# .. envvar:: tinc_extra_options
+# .. envvar:: tinc__extra_options
 #
 # String with extra options to be passed to all ``tincd`` instances in the
 # ``/etc/default/tinc`` config file
-tinc_extra_options: ''
+tinc__extra_options: ''
 
 
-# .. envvar:: tinc_systemd
+# .. envvar:: tinc__systemd
 #
 # Enable support for ``systemd`` if it's detected as the init system.
-tinc_systemd: '{{ True
-                  if (ansible_local|d() and ansible_local.init|d() and
-                      ansible_local.init == "systemd")
-                  else False }}'
+tinc__systemd: '{{ True
+                   if (ansible_local|d() and ansible_local.init|d() and
+                       ansible_local.init == "systemd")
+                   else False }}'
 
 
 # -----------------------------
 #   tinc daemon configuration
 # -----------------------------
 
-# .. envvar:: tinc_rsa_key_length
+# .. envvar:: tinc__rsa_key_length
 #
 # Length of the RSA private key generated on each node
-tinc_rsa_key_length: '4096'
+tinc__rsa_key_length: '4096'
 
 
-# .. envvar:: tinc_hwaddr_prefix
+# .. envvar:: tinc__hwaddr_prefix
 #
 # A stable MAC address prefix that will make sure that the randomly generated
 # MAC address of any Tinc interface is located within a set of Locally
 # Administered Address Ranges. https://serverfault.com/questions/40712/
-tinc_hwaddr_prefix: 'de'
+tinc__hwaddr_prefix: 'de'
 
 
-# .. envvar:: tinc_host_addresses
+# .. envvar:: tinc__host_addresses
 #
 # List of FQDN or IP addresses which are included in the public key file of
 # a given host. Other hosts will use these addresses to connect to that host.
-tinc_host_addresses: '{{ tinc_host_addresses_fqdn }}'
+tinc__host_addresses: '{{ tinc__host_addresses_fqdn }}'
 
 
-# .. envvar:: tinc_host_addresses_fqdn
+# .. envvar:: tinc__host_addresses_fqdn
 #
 # Include the host FQDN if public IP addresses are available.
-tinc_host_addresses_fqdn: '{{ ansible_fqdn
-                              if ((ansible_all_ipv4_addresses + (ansible_all_ipv6_addresses |
-                                  difference(ansible_all_ipv6_addresses | ipaddr("link-local")))
-                                  ) | ipaddr("public")) else [] }}'
+tinc__host_addresses_fqdn: '{{ ansible_fqdn
+                               if ((ansible_all_ipv4_addresses + (ansible_all_ipv6_addresses |
+                                   difference(ansible_all_ipv6_addresses | ipaddr("link-local")))
+                                   ) | ipaddr("public")) else [] }}'
 
 
-# .. envvar:: tinc_host_addresses_ip
+# .. envvar:: tinc__host_addresses_ip
 #
 # Include all public and private IP addresses, without IPv6 link-local.
-tinc_host_addresses_ip: '{{ ansible_all_ipv4_addresses + (ansible_all_ipv6_addresses |
-                            difference(ansible_all_ipv6_addresses | ipaddr("link-local"))) }}'
+tinc__host_addresses_ip: '{{ ansible_all_ipv4_addresses + (ansible_all_ipv6_addresses |
+                             difference(ansible_all_ipv6_addresses | ipaddr("link-local"))) }}'
 
 
 # ------------------
 #   Kernel modules
 # ------------------
 
-# .. envvar:: tinc_modprobe
+# .. envvar:: tinc__modprobe
 #
 # Load required kernel modules if they are not present, and ensure that they
 # are loaded at boot time.
-tinc_modprobe: True
+tinc__modprobe: True
 
 
-# .. envvar:: tinc_modprobe_modules
+# .. envvar:: tinc__modprobe_modules
 #
 # List of kernel modules to load.
-tinc_modprobe_modules: [ 'tun' ]
+tinc__modprobe_modules: [ 'tun' ]
 
 
 # ----------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -268,6 +268,23 @@ tinc_host_addresses_ip: '{{ ansible_all_ipv4_addresses + (ansible_all_ipv6_addre
                             difference(ansible_all_ipv6_addresses | ipaddr("link-local"))) }}'
 
 
+# ------------------
+#   Kernel modules
+# ------------------
+
+# .. envvar:: tinc_modprobe
+#
+# Load required kernel modules if they are not present, and ensure that they
+# are loaded at boot time.
+tinc_modprobe: True
+
+
+# .. envvar:: tinc_modprobe_modules
+#
+# List of kernel modules to load.
+tinc_modprobe_modules: [ 'tun' ]
+
+
 # ----------------------------------------
 #   Configuration of other Ansible roles
 # ----------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,7 +60,7 @@ tinc_network_mesh0:
 # .. envvar:: tinc_interface_mesh0
 #
 # Name of the network interface to use for the Tinc ``mesh0`` VPN.
-tinc_interface_mesh0: 'tap0'
+tinc_interface_mesh0: 'tap-mesh0'
 
 
 # .. envvar:: tinc_link_type_mesh0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,66 +5,181 @@
 # .. contents:: Sections
 #    :local:
 #
-# -----------------------------
-#   General tinc node options
-# -----------------------------
+# -------------------------
+#   Network configuration
+# -------------------------
 
-# .. envvar:: tinc_connection_type
+# .. envvar:: tinc_networks
 #
-# How this VPN node will be connected to the network:
-#
-# - ``dhcp``: stand alone mode; network interface is started and host asks the
-#   mesh network for an IP address
-#
-# - ``static``: bridge mode; network interface is started and connected to
-#   a specified bridge, no DHCP requests are made
-#
-tinc_connection_type: 'dhcp'
+# List of Tinc Virtual Private Networks to configure. See :ref:`tinc_networks`
+# for more details.
+tinc_networks: []
 
 
-# .. envvar:: tinc_connection_bridge
+# .. envvar:: tinc_default_networks
 #
-# Name of the bridge interface which will be used to connect to the mesh
-# network in the ``static`` mode; by default it's bridge created by
-# ``debops.subnetwork`` role. Set to ``False`` to disable bridged connection.
-tinc_connection_bridge: 'br2'
+# List of default networks which are created by the ``debops.tinc`` role.
+tinc_default_networks: [ '{{ tinc_network_mesh0 }}' ]
 
 
-# .. envvar:: tinc_hostname
+# --------------------------------------
+#   The 'mesh0' Tinc VPN configuration
+# --------------------------------------
+
+# Default Tinc VPN created by the ``debops.tinc`` role. It will create a mesh
+# network between hosts in a switch mode. One of the hosts should provide
+# a bridge to which the ``tun0`` interface will be connected; on that bridge
+# you should configure DHCP and DNS server to provide interface configuration.
+
+# .. envvar:: tinc_network_mesh0
 #
-# Name of this node used in configuration files. Thruought the mesh. Don't
-# change this unless you know what you are doing.
-tinc_hostname: '{{ inventory_hostname_short }}'
+# The dictionary variable which defines the ``mesh0`` network. See
+# :ref:`tinc_networks` for more details about available options. Some of the
+# configuration parameters are exposed in their own default variables to make
+# simple config changes easier.
+tinc_network_mesh0:
+  name: 'mesh0'
+  interface: '{{ tinc_interface_mesh0 }}'
+  hwaddr: '{{ tinc_hwaddr_mesh0 }}'
+  bridge: '{{ tinc_bridge_mesh0 }}'
+  link_type: '{{ tinc_link_type_mesh0 }}'
+  boot: '{{ tinc_boot_mesh0 }}'
+  port: '655'
+  mlock: True
+  chroot: True
+  allow: '{{ tinc_allow_mesh0 }}'
+  user: '{{ tinc_user }}'
+  tinc_options:
+    Mode: 'switch'
+    DeviceType: 'tap'
+    Cipher: 'aes-256-cbc'
+    Digest: 'SHA512'
+    ConnectTo: '{{ tinc_connect_to_mesh0 }}'
+
+
+# .. envvar:: tinc_interface_mesh0
+#
+# Name of the network interface to use for the Tinc ``mesh0`` VPN.
+tinc_interface_mesh0: 'tap0'
+
+
+# .. envvar:: tinc_link_type_mesh0
+#
+# Link type to set for the Tinc ``mesh0`` VPN. If empty, ``debops.tinc``
+# defaults to a standalone network interface with ``dhclient`` requesting
+# network configuration using DHCP. Possible values are:
+#
+# - ``static``: set the Tinc interface in a "static" mode with an IP address,
+#   optionally attached to a network bridge. This should usually be done just
+#   on 1 host in the mesh to provide DHCP/DNS services.
+#
+tinc_link_type_mesh0: ''
+
+
+# .. envvar:: tinc_hwaddr_mesh0
+#
+# Specify the Media Access Control address of the Tinc ``mesh0`` interface. If
+# not specified, a randomized stable MAC address will be generated
+# automatically. Set the MAC address value to ``'*'`` to generate a random
+# hardware address.
+tinc_hwaddr_mesh0: ''
+
+
+# .. envvar:: tinc_boot_mesh0
+#
+# Specify if the Tinc ``mesh0`` network should be started at boot.
+tinc_boot_mesh0: True
+
+
+# .. envvar:: tinc_bridge_mesh0
+#
+# Name of the bridge to connect the interface of the Tinc ``mesh0`` VPN. This
+# should be set on a host that provides the DHCP and DNS services for the mesh.
+tinc_bridge_mesh0: ''
+
+
+# .. envvar:: tinc_allow_mesh0
+#
+# List of IP addresses or CIDR subnets which will be allowed to connect to the
+# Tinc ``mesh0`` VPN port (655) through the firewall. If this list is empty,
+# any IP address can connect.
+tinc_allow_mesh0: []
+
+
+# .. envvar:: tinc_connect_to_mesh0
+#
+# List of hosts specified as the ``ConnectTo`` option in the Tinc configuration
+# file of the ``mesh0`` network.
+tinc_connect_to_mesh0: '{{ tinc_inventory_hosts_mesh0 + tinc_external_hosts_mesh0 }}'
+
+
+# .. envvar:: tinc_inventory_hosts_mesh0
+#
+# List of other hosts in the Ansible inventory that are participating in the
+# ``mesh0`` network besides the current one. They will be listed in the
+# ``ConnectTo`` option. This only makes sense if specified hosts have a public
+# IP address. If not, you might want to specify the list of hosts to connect to
+# manually, otherwise Tinc will try and connect to the unreachable hosts all
+# the time.
+tinc_inventory_hosts_mesh0: '{{ (groups.debops_service_tinc_mesh0
+                                   if groups.debops_service_tinc_mesh0|d()
+                                   else []) | difference([ tinc_hostname ]) }}'
+
+
+# .. envvar:: tinc_external_hosts_mesh0
+#
+# List of hosts to connect to which are not in the Ansible inventory. You
+# should provide the corresponding public key files through the directories in
+# ``secret/`` directory.
+tinc_external_hosts_mesh0: []
+
+
+# ----------------
+#   APT packages
+# ----------------
+
+# .. envvar:: tinc_base_packages
+#
+# List of APT packages to install for ``tinc`` support.
+tinc_base_packages: [ 'tinc' ]
+
+
+# .. envvar:: tinc_packages
+#
+# List of additional APT packages to install during ``tinc`` configuration.
+tinc_packages: []
+
+
+# --------------------------------
+#   Ansible inventory parameters
+# --------------------------------
+
+# .. envvar:: tinc_inventory_groups
+#
+# List of Ansible inventory groups which are used by ``debops.tinc`` role to
+# manage separate ``tinc`` networks. Each group will have corresponding
+# directory in the ``secret/`` store on Ansible Controller.
+#
+# The default Ansible group ``debops_service_tinc_mesh0`` specifies hosts that
+# are participating in the ``mesh0`` VPN.
+tinc_inventory_groups: [ 'debops_service_tinc_mesh0' ]
 
 
 # .. envvar:: tinc_inventory_hosts
 #
-# List of hosts from Ansible inventory which will be used to gather the tinc
-# public keys and connect to form the mesh.
-tinc_inventory_hosts: '{{ groups.debops_tinc }}'
+# This list defines what hosts in Ansible inventory participate in a Tinc VPN.
+# They will have their own directories in ``secret/`` store on Ansible
+# Controller used to distribute public host keys.
+tinc_inventory_hosts: '{{ groups.debops_service_tinc
+                          if groups.debops_service_tinc|d()
+                          else [] }}'
 
 
-# .. envvar:: tinc_external_hosts
+# .. envvar:: tinc_hostname
 #
-# Dict variable which defines mesh nodes outside of the Ansible inventory. Each
-# key is the name of the node, and value is the content of that node host file
-# in YAML text block format, or a ``lookup()`` output. See
-# :ref:`tinc_external_hosts` for more details.
-tinc_external_hosts: {}
-
-
-# .. envvar:: tinc_connect_to
-#
-# List of hosts which this ``tinc`` node should connect to; by default each
-# node connects to every other node.
-tinc_connect_to: '{{ tinc_inventory_hosts + tinc_external_hosts.keys()|d([]) }}'
-
-
-# .. envvar:: tinc_ferm_allow_any
-#
-# Enable or disable external access to ``tinc`` VPN through the firewall.
-# If access is disabled, only outgoing connections will work.
-tinc_ferm_allow_any: True
+# Name of this node used in configuration files thruought the mesh. Don't
+# change this unless you know what you are doing.
+tinc_hostname: '{{ inventory_hostname_short }}'
 
 
 # ---------------------------
@@ -89,13 +204,6 @@ tinc_group: 'tinc-vpn'
 tinc_home: '/etc/tinc'
 
 
-# .. envvar:: tinc_network
-#
-# Name of the network configuration in ``/etc/tinc/`` which is managed by this
-# instance of the ``debops.tinc`` role.
-tinc_network: 'mesh0'
-
-
 # .. envvar:: tinc_ulimit_options
 #
 # List of options passed to ``ulimit`` command before starting ``tincd``
@@ -103,157 +211,74 @@ tinc_network: 'mesh0'
 tinc_ulimit_options: '-l {{ (1024 * 64) }}'
 
 
-# .. envvar:: tinc_rsa_key_length
+# .. envvar:: tinc_extra_options
 #
-# Length of the RSA private key generated on each node
-tinc_rsa_key_length: '4096'
+# String with extra options to be passed to all ``tincd`` instances in the
+# ``/etc/default/tinc`` config file
+tinc_extra_options: ''
 
 
-# -----------------------------------
-#   Network interface configuration
-# -----------------------------------
-
-# .. envvar:: tinc_interface
+# .. envvar:: tinc_systemd
 #
-# Network interface used by the ``tincd`` daemon.
-tinc_interface: 'tap2'
-
-
-# .. envvar:: tinc_interface_auto
-#
-# Start VPN interface on boot as well as during the Ansible run, or update
-# daemon configuration. Set to ``False`` to not start the VPN automatically and
-# not notify the ``tincd`` daemon about changes.
-tinc_interface_auto: True
-
-
-# .. envvar:: tinc_ifupdown_interfaces
-#
-# Configuration of the VPN network interface passed to ``debops.ifupdown``
-# role using role dependency variables.
-tinc_ifupdown_interface:
-  iface: '{{ tinc_interface }}'
-  type: 'interface'
-  weight: '75'
-  inet: '{{ tinc_connection_type }}'
-  auto: '{{ tinc_interface_auto }}'
-  auto_ifup: False
-  force: True
-  options: |
-    {% if ansible_local.init != 'systemd' %}
-    tinc-net {{ tinc_network }}
-    tinc-chroot yes
-    tinc-mlock yes
-    tinc-user {{ tinc_user }}
-    {% endif %}
-    {% if tinc_connection_type == 'static' %}
-    {{ tinc_ifupdown_options_static[tinc_interface]|d() }}
-    {% elif tinc_connection_type == 'dhcp' %}
-    {{ tinc_ifupdown_options_dhcp[tinc_interface]|d() }}
-    {% endif %}
-
-
-# .. envvar:: tinc_ifupdown_options_static
-#
-# Dict with additional options for the VPN network interface configured in the
-# ``static`` mode, each interface name needs to be written normally, not as
-# a variable. Options are specified in a YAML text block.
-tinc_ifupdown_options_static:
-  'tap2': |
-    address 0.0.0.0
-    {% if tinc_connection_bridge|d() and tinc_connection_bridge %}
-    post-up brctl addif {{ tinc_connection_bridge }} {{ tinc_interface }}
-    pre-down brctl delif {{ tinc_connection_bridge }} {{ tinc_interface }}
-    {% endif %}
-
-
-# .. envvar:: tinc_ifupdown_options_dhcp
-#
-# Dict with additional options for the VPN network interface configured in the
-# ``dhcp`` mode, each interface name needs to be written normally, not as
-# a variable. Options are specified in a YAML text block.
-tinc_ifupdown_options_dhcp: {}
+# Enable support for ``systemd`` if it's detected as the init system.
+tinc_systemd: '{{ True
+                  if (ansible_local|d() and ansible_local.init|d() and
+                      ansible_local.init == "systemd")
+                  else False }}'
 
 
 # -----------------------------
 #   tinc daemon configuration
 # -----------------------------
 
-# .. envvar:: tinc_configuration
+# .. envvar:: tinc_rsa_key_length
 #
-# Dict with main configuration variables for ``tincd``. Each key is name of the
-# config option, value is the value set for that option. See ``tinc.conf(5)``
-# "SERVER CONFIGURATION" section for possible configuration options.
-tinc_configuration:
-  Mode: 'switch'
-  Port: '{{ tinc_host_port }}'
-  DeviceType: 'tap'
-  ConnectTo: '{{ tinc_connect_to | difference([ tinc_hostname ]) }}'
+# Length of the RSA private key generated on each node
+tinc_rsa_key_length: '4096'
 
 
-# .. envvar:: tinc_daemon_configuration
+# .. envvar:: tinc_hwaddr_prefix
 #
-# Dict with additional configuration options for ``tincd``, it will be added to
-# configuration options in in ``tinc_configuration`` variable. Entries from
-# ``tinc_daemon_configuration`` will override those set in
-# ``tinc_configuration``.
-tinc_daemon_configuration: {}
-
-
-# .. envvar:: tinc_host_configuration
-#
-# Dict with configuration options for the host file in
-# ``/etc/tinc/<network>/hosts/<hostname>``. See ``tinc.conf(5)`` "HOST
-# CONFIGURATION FILES" section for available options.
-tinc_host_configuration: {}
+# A stable MAC address prefix that will make sure that the randomly generated
+# MAC address of any Tinc interface is located within a set of Locally
+# Administered Address Ranges. https://serverfault.com/questions/40712/
+tinc_hwaddr_prefix: 'de'
 
 
 # .. envvar:: tinc_host_addresses
 #
-# List of IP addresses on which ``tincd`` should listen for new connections,
-# will be specified in the host file. If not set, ``tincd`` will listen for
-# connections on all available public IP addresses.
-tinc_host_addresses: []
+# List of FQDN or IP addresses which are included in the public key file of
+# a given host. Other hosts will use these addresses to connect to that host.
+tinc_host_addresses: '{{ tinc_host_addresses_fqdn }}'
 
 
-# .. envvar:: tinc_host_port
+# .. envvar:: tinc_host_addresses_fqdn
 #
-# Which port ``tincd`` should listen for new connections.
-tinc_host_port: '655'
+# Include the host FQDN if public IP addresses are available.
+tinc_host_addresses_fqdn: '{{ ansible_fqdn
+                              if ((ansible_all_ipv4_addresses + (ansible_all_ipv6_addresses |
+                                  difference(ansible_all_ipv6_addresses | ipaddr("link-local")))
+                                  ) | ipaddr("public")) else [] }}'
 
 
-# .. envvar:: tinc_scripts
+# .. envvar:: tinc_host_addresses_ip
 #
-# Dict with custom scripts for ``tincd``, each key is name of the script, value
-# in YAML text block format will be set as contents of the file. See
-# ``tinc.conf(5)`` "SCRIPTS" section to see possible script names and their
-# purpose.
-tinc_scripts: {}
+# Include all public and private IP addresses, without IPv6 link-local.
+tinc_host_addresses_ip: '{{ ansible_all_ipv4_addresses + (ansible_all_ipv6_addresses |
+                            difference(ansible_all_ipv6_addresses | ipaddr("link-local"))) }}'
 
-# .. envvar:: tinc_extra_options
-#
-# String with extra options to be passed to tincd in the 
-# /etc/default/tinc config file
-tinc_extra_options: ''
 
-# .. envvar:: tinc_apt_preferences_dependent_list
+# ----------------------------------------
+#   Configuration of other Ansible roles
+# ----------------------------------------
+
+# .. envvar:: tinc__apt_preferences__dependent_list
 #
-# Configuration of custom APT preferences.
-tinc_apt_preferences_dependent_list:
+# Configuration of ``debops.apt_preferences`` role.
+tinc__apt_preferences__dependent_list:
 
   - package: 'tinc'
     backports: [ 'wheezy' ]
     reason:  'Backport installed on Wheezy for version parity with Debian Jessie'
     by_role: 'debops.tinc'
-
-# .. envvar:: tinc_ferm_dependent_rules
-#
-# Configuration for ``iptables`` firewall managed by ``ferm``.
-tinc_ferm_dependent_rules:
-
-  - type: 'accept'
-    protocol: [ 'tcp', 'udp' ]
-    dport: [ '{{ tinc_host_port }}' ]
-    accept_any: '{{ tinc_ferm_allow_any }}'
-    filename: 'tinc'
 

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -9,10 +9,10 @@ them.
    :local:
    :depth: 1
 
-.. _tinc_networks:
+.. _tinc__networks:
 
-tinc_networks
--------------
+tinc__networks
+--------------
 
 This is a list of mesh networks managed by ``debops.tinc`` role. Each network
 is described by a YAML dictionary which should have the following keys:
@@ -77,7 +77,7 @@ is described by a YAML dictionary which should have the following keys:
 
   To see the list of available options, check the ``tinc.conf(5)`` manual page.
 
-``host_options``
+``tinc_host_options``
   Optional. Dictionary variable which specifies options stored in the
   ``/etc/tinc/<network>/hosts/<hostname>`` configuration file. Each key of the
   dict is the option name, values can be strings or lists of strings, in which
@@ -91,9 +91,9 @@ Examples
 
 Minimal configuration of a default Tinc ``mesh0`` VPN::
 
-    tinc_networks: [ '{{ tinc_network_mesh0 }}' ]
+    tinc__networks: [ '{{ tinc__network_mesh0 }}' ]
 
-    tinc_network_mesh0:
+    tinc__network_mesh0:
       name: 'mesh0'
       interface: 'tap0'
       port: '655'

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -9,34 +9,95 @@ them.
    :local:
    :depth: 1
 
-.. _tinc_external_hosts:
+.. _tinc_networks:
 
-tinc_external_hosts
--------------------
+tinc_networks
+-------------
 
-This is a dict variable which specifies the host name and configuration of
-external VPN hosts which should be connected to the mesh network. Dict key
-should be the hostname of the external host, dict value specifies the contents
-of the host configuration file stored in
-``/etc/tinc/<network>/hosts/<hostname>``. It should contain at least the list
-of addresses on which connections can be made and RSA public key of the remote
-host. Contents of the host file can be specified either as YAML text block, or
-can be stored in a file accessed via ``lookup('file')`` plugin.
+This is a list of mesh networks managed by ``debops.tinc`` role. Each network
+is described by a YAML dictionary which should have the following keys:
 
-Examples:
-~~~~~~~~~
+``name``
+  Required. Name of the mesh network, used as the name of the directory in
+  ``/etc/tinc/`` as well as the ``systemd`` instance argument.
 
-Example external host configuration::
+``interface``
+  Required. Name of the virtual Ethernet device which will be managed by the
+  Tinc VPN. Using names like ``tunX`` or ``tapX`` will ensure that DNS
+  configuration received from the nameserver will be ordered correctly by
+  ``resolvconf`` package.
 
-    tinc_external_hosts:
+``port``
+  Required. TCP and UDP port used by this Tinc VPN.
 
-      'hostname': |
-        Address = 10.10.99.128
+``allow``
+  Optional. List of IP addresses or CIDR subnets whould be allowed to connect
+  to this VPN port through the firewall. If the list is not specified or empty,
+  any host or network can connect.
 
-        -----BEGIN RSA PUBLIC KEY-----
-        MIICCgKCAgEAzrxMnWk7KjS5YaGedXHfAFqcRTTeYM28d6uGpTDiel0Lgl3SjgFy
-        3Xuf41/RgExm2bOAhK1vIcxZnkALxcwQiVYsfASINEG0P9S7KNK+WUZ6ArnJYn6U
-        ...
-        qZARwVnml+Sknx22NJFwgWzklUIK3j+/3Eudxzu9JkGVeE9EkhRNoel9TVgGf3kj
-        -----END RSA PUBLIC KEY-----
+``bridge``
+  Optional. Name of the network bridge to which the virtual Ethernet device
+  will be connected, if the interface is configured in the "static" mode.
+
+``link_type``
+  Optional. Specify a special interface mode which should be used on a given
+  mesh host. By default, if this argument is not specified, node will ask the
+  mesh for the network configuration via DHCP. If you set it to ``static``,
+  a static IP address will be configured on the interface.
+
+``hwaddr``
+  Optional. By default the ``tinc-up`` script will create the virtual Ethernet
+  device with a random, but predictable and not changing MAC address. Using
+  ``item.hwaddr`` you can specify your own MAC address (in the format accepted
+  by ``ip link`` command). If you specify the MAC address as ``*``, a random
+  one will be generated.
+
+``boot``
+  Optional, boolean. Enable or disable start of the given Tinc VPN at boot
+  time. By default all mesh networks are started at boot.
+
+``user``
+  Optional. Name of the UNIX user account under which the ``tincd`` daemon will
+  be running. If not specified, ``tincd`` will be run under ``root`` account.
+
+``mlock``
+  Optional, boolean. If present and ``True``, ``tincd`` will be executed with
+  the ``--mlock`` option which will lock the daemon's memory in RAM, preventing
+  the system from moving it to the swap space.
+
+``chroot``
+  Optional, boolean. If ``True``, the ``tincd`` daemon will be run chrooted to
+  the directory with the VPN configuration files.
+
+``tinc_options``
+  Required. Dictionary variable which specifies options stored in the
+  ``/etc/tinc/<network>/tinc.conf`` configuration file. Each key of the dict is
+  the option name, values can be strings or lists of strings, in which case the
+  option will be repeated as many times as there are elements in the list.
+
+  To see the list of available options, check the ``tinc.conf(5)`` manual page.
+
+``host_options``
+  Optional. Dictionary variable which specifies options stored in the
+  ``/etc/tinc/<network>/hosts/<hostname>`` configuration file. Each key of the
+  dict is the option name, values can be strings or lists of strings, in which
+  case the option will be repeated as many times as there are elements in the
+  list.
+
+  To see the list of available options, check the ``tinc.conf(5)`` manual page.
+
+Examples
+~~~~~~~~
+
+Minimal configuration of a default Tinc ``mesh0`` VPN::
+
+    tinc_networks: [ '{{ tinc_network_mesh0 }}' ]
+
+    tinc_network_mesh0:
+      name: 'mesh0'
+      interface: 'tap0'
+      port: '655'
+      tinc_options:
+        Mode: 'switch'
+        DeviceType: 'tap'
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -34,7 +34,7 @@ hosts acting as the DHCP/DNS server and optionally a gateway::
     debops_service_tinc_mesh0
 
     [debops_service_tinc_mesh0]
-    gateway   tinc_bridge_mesh0="br2" tinc_link_type_mesh0="static"
+    gateway   tinc__bridge_mesh0="br2" tinc__link_type_mesh0="static"
     hostname1
     hostname2
 
@@ -52,7 +52,7 @@ connections between hosts, you can tell the ``debops.tinc`` role to add the
 private IP addresses of the hosts to their public key files by adding in the
 Ansible inventory::
 
-    tinc_host_addresses: '{{ tinc_host_addresses_ip }}'
+    tinc__host_addresses: '{{ tinc__host_addresses_ip }}'
 
 Example playbook
 ----------------
@@ -79,7 +79,7 @@ Here's an example playbook which uses ``debops.tinc`` role::
 
         - role: debops.secret
           tags: [ 'role::secret', 'role::tinc:secret' ]
-          secret_directories: '{{ tinc_env_secret_directories }}'
+          secret_directories: '{{ tinc__env_secret__directories }}'
 
         - role: debops.apt_preferences
           tags: [ 'role::apt_preferences' ]
@@ -87,11 +87,11 @@ Here's an example playbook which uses ``debops.tinc`` role::
 
         - role: debops.etc_services
           tags: [ 'role::etc_services' ]
-          etc_services_dependent_list: '{{ tinc_etc_services_dependent_list }}'
+          etc_services_dependent_list: '{{ tinc__env_etc_services__dependent_list }}'
 
         - role: debops.ferm
           tags: [ 'role::ferm' ]
-          ferm_dependent_rules: '{{ tinc_env_ferm_dependent_rules }}'
+          ferm_dependent_rules: '{{ tinc__env_ferm__dependent_rules }}'
 
         - role: debops.tinc
           tags: [ 'role::tinc' ]
@@ -109,7 +109,7 @@ a bridge which connects to a network with DHCP/DNS server:
 
 .. code-block:: yaml
 
-   tinc_network_dict:
+   tinc__network_dict:
      link_type: 'static'
      bridge: 'br2'
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -14,44 +14,104 @@ network.
 Example inventory
 -----------------
 
-Hosts added in ``[debops_tinc]`` inventory group will have the ``tinc`` daemon
-installed and configured. By default, role will exchange the public RSA keys
-between all of the hosts in that group and define connections between all of
-them, you can change that using ``tinc_inventory_hosts`` list variable.
+Hosts added in ``[debops_service_tinc]`` inventory group will have the ``tinc``
+daemon installed and configured.
 
-::
+Additionally, you need to add hosts to a separate inventory group which defines
+which hosts belong in a particular VPN mesh. For the default ``mesh0`` VPN, you
+should use the ``[debops_service_tinc_mesh0]`` group.
 
-    [debops_tinc]
+Here's example inventory that defines a Tinc ``mesh0`` VPN with one of the
+hosts acting as the DHCP/DNS server and optionally a gateway::
+
+    [debops_service_subnetwork]
+    gateway
+
+    [debops_service_dnsmasq]
+    gateway
+
+    [debops_service_tinc:children]
+    debops_service_tinc_mesh0
+
+    [debops_service_tinc_mesh0]
+    gateway   tinc_bridge_mesh0="br2" tinc_link_type_mesh0="static"
     hostname1
     hostname2
 
+By default Tinc configures host public keys to contain the primary FQDN address
+of a given host, so that when its IP address changes, Tinc will interrogate the
+DNS to get the current IP address.
+
+However, the FQDN will only be added, if a given host has a publicly routable
+IP address. This means that hosts without public IPs won't have their addresses
+mentioned in their public key files. This allows these hosts to still connect
+to public gateway with access to the Tinc network.
+
+If you want to test the Tinc VPN only on a private network, or allow VPN
+connections between hosts, you can tell the ``debops.tinc`` role to add the
+private IP addresses of the hosts to their public key files by adding in the
+Ansible inventory::
+
+    tinc_host_addresses: '{{ tinc_host_addresses_ip }}'
 
 Example playbook
 ----------------
+
+The ``debops.tinc`` role uses other roles present in the DebOps project to
+configure certain aspects of a host, like firewall, installation of the
+``tinc`` package from Debian Backports repository on certain OS releases, and
+so on. To do that, a special Ansible playbook is used to access other roles.
+A "mini role" called ``debops.tinc/env`` is used to pass variable data
+generated from templates to other roles.
 
 Here's an example playbook which uses ``debops.tinc`` role::
 
     ---
 
     - name: Configure tinc VPN
-      hosts: debops_tinc
+      hosts: [ 'debops_service_tinc' ]
+      become: True
 
       roles:
+
+        - role: debops.tinc/env
+          tags: [ 'role::tinc', 'role::tinc:secret', 'role::secret', 'role::ferm', 'role::ifupdown' ]
+
+        - role: debops.secret
+          tags: [ 'role::secret', 'role::tinc:secret' ]
+          secret_directories: '{{ tinc_env_secret_directories }}'
+
+        - role: debops.apt_preferences
+          tags: [ 'role::apt_preferences' ]
+          apt_preferences_dependent_list: '{{ tinc__apt_preferences__dependent_list }}'
+
+        - role: debops.etc_services
+          tags: [ 'role::etc_services' ]
+          etc_services_dependent_list: '{{ tinc_etc_services_dependent_list }}'
+
+        - role: debops.ferm
+          tags: [ 'role::ferm' ]
+          ferm_dependent_rules: '{{ tinc_env_ferm_dependent_rules }}'
+
         - role: debops.tinc
-          tags: tinc
+          tags: [ 'role::tinc' ]
 
 Static vs DHCP connection type
 ------------------------------
 
 By default, ``debops.tinc`` role configures a node to start its VPN interface
 in a "DHCP" mode, without connecting to any other bridge interface, and ask the
-mesh network for an IP address. If no DHCP server was configured, host might
-hang indefinitely waiting for a DHCP response.
+mesh network for an IP address.
 
-To avoid above issue, you need to configure at least one VPN host to work in
-a "static" mode::
+To have properly configured networking in the mesh, you need to configure at
+least one VPN host to work in a "static" mode and preferably connect it to
+a bridge which connects to a network with DHCP/DNS server:
 
-    tinc_connection_type: 'static'
+.. code-block:: yaml
+
+   tinc_network_dict:
+     link_type: 'static'
+     bridge: 'br2'
 
 In this mode, host will be configured to start the VPN interface with a dummy
 ``0.0.0.0`` IP address and connect it to a bridge, by default ``br2``. This
@@ -65,11 +125,67 @@ server. You can configure a DHCP/DNS server using ``debops.dnsmasq`` role.
 RSA public key exchange
 -----------------------
 
-``debops.tinc`` role will automatically exchange public RSA VPN keys between
-all hosts in group specified in ``tinc_inventory_hosts`` list variable,
-provided that the host information as been gathered by Ansible. In other words,
-to exchange the keys, you need to execute the Ansible run on all or part of the
-hosts in the specified group::
+The ``debops.tinc`` role uses directories created in the ``secret/tinc/``
+directory on Ansible Controller to exchange RSA public keys between hosts in
+a given VPN. Each network has its own directory tree::
 
-    debops -l debops_tinc -t tinc
+    secret/tinc/
+    └── networks/
+        └── mesh0/
+            ├── by-group/
+            │   ├── all/
+            │   │   └── hosts/
+            │   └── debops_service_tinc_mesh0/
+            │       └── hosts/
+            ├── by-host/
+            │   ├── gateway/
+            │   │   └── hosts/
+            │   ├── hostname1/
+            │   │   └── hosts/
+            │   └── hostname/
+            │       └── hosts/
+            └── by-network/
+                └── mesh0/
+                    └── hosts/
+                        ├── gateway
+                        ├── hostname1
+                        └── hostname2
+
+By default all public keys in a given mesh network will be stored in::
+
+    secret/tinc/networks/<mesh>/by-network/<mesh>/hosts/
+
+The ``by-group/all/hosts/`` directory can be used to distribute public keys to
+all hosts in a given mesh network. You can also distirbute the keys only to
+hosts in a particular Ansible group, or even to a specific host.
+
+Only the hosts in the current ``ansible-playbook`` run will get the keys
+present in the ``hosts/`` directories. This means that when you add a new host
+to the mesh, you will need to run the role on all the hosts that you want to
+have connections with, otherwise the new host won't be accepted by the mesh due
+to uknown public keys.
+
+Support for systemd tinc@.service instances
+-------------------------------------------
+
+On a legacy systems without ``systemd``, you can manage Tinc VPN networks using
+the ``/etc/init.d/tinc`` init script.
+
+If ``systemd`` is detected as the current init process, ``debops.tinc`` will
+configure a set of ``systemd`` unit files:
+
+``tinc.service``
+  This is the main unit that manages all of the Tinc VPN networks and
+  propagates start/stop/restart events.
+
+``tinc@.service``
+  This unit can be used to manage individual Tinc networks. The unit argument
+  is the name of the VPN.
+
+With ``systemd``, you can manage each Tinc network separately by issuing
+commands::
+
+    systemctl status tinc@mesh0
+    systemctl start tinc@mesh0
+    systemctl stop tinc@mesh0
 

--- a/env/defaults
+++ b/env/defaults
@@ -1,0 +1,1 @@
+../defaults

--- a/env/tasks/main.yml
+++ b/env/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Prepare debops.tinc environment
   set_fact:
-    tinc_env_secret_directories:          '{{ lookup("template", "lookup/tinc_env_secret_directories.j2")          | from_yaml }}'
-    tinc_env_etc_services_dependent_list: '{{ lookup("template", "lookup/tinc_env_etc_services_dependent_list.j2") | from_yaml }}'
-    tinc_env_ferm_dependent_rules:        '{{ lookup("template", "lookup/tinc_env_ferm_dependent_rules.j2")        | from_yaml }}'
+    tinc__env_secret__directories:          '{{ lookup("template", "lookup/tinc_env_secret_directories.j2")          | from_yaml }}'
+    tinc__env_etc_services__dependent_list: '{{ lookup("template", "lookup/tinc_env_etc_services_dependent_list.j2") | from_yaml }}'
+    tinc__env_ferm__dependent_rules:        '{{ lookup("template", "lookup/tinc_env_ferm_dependent_rules.j2")        | from_yaml }}'
 

--- a/env/tasks/main.yml
+++ b/env/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Prepare debops.tinc environment
+  set_fact:
+    tinc_env_secret_directories:          '{{ lookup("template", "lookup/tinc_env_secret_directories.j2")          | from_yaml }}'
+    tinc_env_etc_services_dependent_list: '{{ lookup("template", "lookup/tinc_env_etc_services_dependent_list.j2") | from_yaml }}'
+    tinc_env_ferm_dependent_rules:        '{{ lookup("template", "lookup/tinc_env_ferm_dependent_rules.j2")        | from_yaml }}'
+

--- a/env/templates/lookup/tinc_env_etc_services_dependent_list.j2
+++ b/env/templates/lookup/tinc_env_etc_services_dependent_list.j2
@@ -1,0 +1,12 @@
+{% set tinc__tpl_default_port = '655' %}
+{% for network in (tinc_default_networks + tinc_networks) %}
+{% if (network.name|d() and (network.tinc_options|d() or network.port|d()) and
+       ((network.tinc_options.Port|d() and network.tinc_options.Port != tinc__tpl_default_port) or
+        (network.port|d() and network.port != tinc__tpl_default_port))) %}
+  - name: '{{ "tinc-" + network.name }}'
+    port: '{{ network.tinc_options.Port if network.tinc_options.Port|d() else network.port }}'
+    protocols: [ 'tcp', 'udp' ]
+    comment: '{{ "tinc " + network.name + " VPN" }}'
+
+{% endif %}
+{% endfor %}

--- a/env/templates/lookup/tinc_env_etc_services_dependent_list.j2
+++ b/env/templates/lookup/tinc_env_etc_services_dependent_list.j2
@@ -1,5 +1,5 @@
 {% set tinc__tpl_default_port = '655' %}
-{% for network in (tinc_default_networks + tinc_networks) %}
+{% for network in (tinc__default_networks + tinc__networks) %}
 {% if (network.name|d() and (network.tinc_options|d() or network.port|d()) and
        ((network.tinc_options.Port|d() and network.tinc_options.Port != tinc__tpl_default_port) or
         (network.port|d() and network.port != tinc__tpl_default_port))) %}

--- a/env/templates/lookup/tinc_env_ferm_dependent_rules.j2
+++ b/env/templates/lookup/tinc_env_ferm_dependent_rules.j2
@@ -1,4 +1,4 @@
-{% for network in (tinc_default_networks + tinc_networks) %}
+{% for network in (tinc__default_networks + tinc__networks) %}
 {% if network.name|d() and (network.tinc_options|d() or network.port|d()) %}
   - type: 'accept'
     protocol: [ 'tcp', 'udp' ]

--- a/env/templates/lookup/tinc_env_ferm_dependent_rules.j2
+++ b/env/templates/lookup/tinc_env_ferm_dependent_rules.j2
@@ -1,0 +1,14 @@
+{% for network in (tinc_default_networks + tinc_networks) %}
+{% if network.name|d() and (network.tinc_options|d() or network.port|d()) %}
+  - type: 'accept'
+    protocol: [ 'tcp', 'udp' ]
+    dport: [ '{{ network.tinc_options.Port if network.tinc_options.Port|d() else network.port }}' ]
+{% if network.allow|d() %}
+    saddr: {{ ("[ '" + network.allow + "' ]") if (network.allow is string) else ("[ '" + network.allow | join("', '") + "' ]") }}
+{% endif %}
+    role: 'tinc'
+    name: '{{ network.name }}'
+    delete: '{{ (True if network.delete|d() else False) | bool }}'
+
+{% endif %}
+{% endfor %}

--- a/env/templates/lookup/tinc_env_secret_directories.j2
+++ b/env/templates/lookup/tinc_env_secret_directories.j2
@@ -1,0 +1,16 @@
+{% for network in (tinc_default_networks + tinc_networks) %}
+{%   if network.name|d() and network.tinc_options|d() %}
+  - 'tinc/networks/{{ network.name }}/by-group/all/hosts'
+  - 'tinc/networks/{{ network.name }}/by-network/{{ network.name }}/hosts'
+{%     for group in tinc_inventory_groups %}
+  - 'tinc/networks/{{ network.name }}/by-group/{{ group }}/hosts'
+{%     endfor %}
+{%     for host in tinc_inventory_hosts %}
+{%       if ((network.name in (tinc_networks | map(attribute="name") | list) or
+              network.name in (tinc_default_networks | map(attribute="name") | list)) and
+             host == tinc_hostname) %}
+  - 'tinc/networks/{{ network.name }}/by-host/{{ host }}/hosts'
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{% endfor %}

--- a/env/templates/lookup/tinc_env_secret_directories.j2
+++ b/env/templates/lookup/tinc_env_secret_directories.j2
@@ -1,14 +1,14 @@
-{% for network in (tinc_default_networks + tinc_networks) %}
+{% for network in (tinc__default_networks + tinc__networks) %}
 {%   if network.name|d() and network.tinc_options|d() %}
   - 'tinc/networks/{{ network.name }}/by-group/all/hosts'
   - 'tinc/networks/{{ network.name }}/by-network/{{ network.name }}/hosts'
-{%     for group in tinc_inventory_groups %}
+{%     for group in tinc__inventory_groups %}
   - 'tinc/networks/{{ network.name }}/by-group/{{ group }}/hosts'
 {%     endfor %}
-{%     for host in tinc_inventory_hosts %}
-{%       if ((network.name in (tinc_networks | map(attribute="name") | list) or
-              network.name in (tinc_default_networks | map(attribute="name") | list)) and
-             host == tinc_hostname) %}
+{%     for host in tinc__inventory_hosts %}
+{%       if ((network.name in (tinc__networks | map(attribute="name") | list) or
+              network.name in (tinc__default_networks | map(attribute="name") | list)) and
+             host == tinc__hostname) %}
   - 'tinc/networks/{{ network.name }}/by-host/{{ host }}/hosts'
 {%       endif %}
 {%     endfor %}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,16 +1,7 @@
 ---
 
-- name: Reload tinc configuration
-  command: tincd -n {{ tinc_network }} -kHUP
-  when: (tinc_interface_auto | bool and ansible_local|d() and ansible_local.cap12s|d() and
-         (not ansible_local.cap12s.enabled | bool or
-          (ansible_local.cap12s.enabled | bool and "cap_net_admin" in ansible_local.cap12s.list)))
-
-- name: Restart tinc VPN connection
-  shell: test -d /run/systemd/system &&
-         ( systemctl restart tinc@{{ tinc_network }}.service) ||
-         ( ifdown {{ tinc_interface }} ; ifup {{ tinc_interface }} )
-  when: (tinc_interface_auto | bool and ansible_local|d() and ansible_local.cap12s|d() and
-         (not ansible_local.cap12s.enabled | bool or
-          (ansible_local.cap12s.enabled | bool and "cap_net_admin" in ansible_local.cap12s.list)))
+- name: Reload tinc
+  service:
+    name: 'tinc'
+    state: 'reloaded'
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
-dependencies: []
+dependencies:
+
+  - role: debops.secret
 
 galaxy_info:
   author: 'Maciej Delmanowski'
@@ -9,18 +11,19 @@ galaxy_info:
   license: 'GNU General Public License v3'
   min_ansible_version: '1.8.0'
   platforms:
-  - name: Ubuntu
-    versions:
-    - precise
-    - quantal
-    - raring
-    - saucy
-    - trusty
-  - name: Debian
-    versions:
-    - wheezy
-    - jessie
-  categories:
-  - networking
-  - system
+    - name: Ubuntu
+      versions:
+      - precise
+      - quantal
+      - raring
+      - saucy
+      - trusty
+    - name: Debian
+      versions:
+      - wheezy
+      - jessie
+  galaxy_tags:
+    - networking
+    - tinc
+    - vpn
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,22 +27,24 @@
     shell: '/bin/false'
     createhome: False
 
-- name: Load the tun kernel module
+- name: Load the required kernel modules
   modprobe:
-    name: 'tun'
+    name: '{{ item }}'
     state: 'present'
-  when: (ansible_local|d() and ansible_local.cap12s|d() and
+  with_items: '{{ tinc_modprobe_modules }}'
+  when: (tinc_modprobe|bool and ansible_local|d() and ansible_local.cap12s|d() and
          (not ansible_local.cap12s.enabled | bool or
           (ansible_local.cap12s.enabled | bool and
            'cap_sys_admin' in ansible_local.cap12s.list)))
 
-- name: Make sure that tun module is loaded on boot
+- name: Make sure that required modules are loaded on boot
   lineinfile:
     dest: '/etc/modules'
-    regexp: '^tun$'
-    line: 'tun'
+    regexp: '^{{ item }}$'
+    line: '{{ item }}'
     state: 'present'
-  when: (ansible_local|d() and ansible_local.cap12s|d() and
+  with_items: '{{ tinc_modprobe_modules }}'
+  when: (tinc_modprobe|bool and ansible_local|d() and ansible_local.cap12s|d() and
          (not ansible_local.cap12s.enabled | bool or
           (ansible_local.cap12s.enabled | bool and
            'cap_sys_admin' in ansible_local.cap12s.list)))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -189,7 +189,7 @@
 
 - name: Download public keys per host
   copy:
-    src: '{{ secret + "/tinc/networks/" + item.name + "/by-host/" + ((item.hostname | d(tinc_hostname)) | replace("-","_")) + "/hosts/" }}'
+    src: '{{ secret + "/tinc/networks/" + item.name + "/by-host/" + ((item.hostname | d(tinc_hostname))) + "/hosts/" }}'
     dest: '/etc/tinc/{{ item.name }}/hosts/'
     owner: 'root'
     group: '{{ tinc_group }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,13 @@
 
 - name: Install required packages
   apt:
-    name: 'tinc'
+    name: '{{ item }}'
     state: 'present'
     install_recommends: False
+  with_flattened:
+    - '{{ tinc_base_packages }}'
+    - '{{ tinc_packages }}'
+  register: tinc_register_install
 
 - name: Create system group for VPN service
   group:
@@ -23,118 +27,216 @@
     shell: '/bin/false'
     createhome: False
 
-- name: Create required directories
-  file:
-    path: '/etc/tinc/{{ tinc_network }}/hosts/{{ tinc_hostname | replace("-","_") }}.d'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
+- name: Load the tun kernel module
+  modprobe:
+    name: 'tun'
+    state: 'present'
+  when: (ansible_local|d() and ansible_local.cap12s|d() and
+         (not ansible_local.cap12s.enabled | bool or
+          (ansible_local.cap12s.enabled | bool and
+           'cap_sys_admin' in ansible_local.cap12s.list)))
 
-- name: Set tincd ulimit options
+- name: Make sure that tun module is loaded on boot
+  lineinfile:
+    dest: '/etc/modules'
+    regexp: '^tun$'
+    line: 'tun'
+    state: 'present'
+  when: (ansible_local|d() and ansible_local.cap12s|d() and
+         (not ansible_local.cap12s.enabled | bool or
+          (ansible_local.cap12s.enabled | bool and
+           'cap_sys_admin' in ansible_local.cap12s.list)))
+
+- name: Set tincd default environment
   template:
     src: 'etc/default/tinc.j2'
     dest: '/etc/default/tinc'
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ 'Restart tinc VPN connection' ]
+  notify: [ 'Reload tinc' ]
+
+- name: Create required directories
+  file:
+    path: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name|d()
 
 - name: Generate main configuration file
   template:
     src: 'etc/tinc/network/tinc.conf.j2'
-    dest: '/etc/tinc/{{ tinc_network }}/tinc.conf'
+    dest: '/etc/tinc/{{ item.name }}/tinc.conf'
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ 'Reload tinc configuration' ]
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name|d() and item.tinc_options|d()
+  notify: [ 'Reload tinc' ]
 
-- name: Generate network scripts when defined
+- name: Generate tinc-up network scripts
   template:
-    src: 'etc/tinc/network/tinc-script.j2'
-    dest: '/etc/tinc/{{ tinc_network }}/{{ item.key }}'
+    src: 'etc/tinc/network/tinc-up.j2'
+    dest: '/etc/tinc/{{ item.name }}/tinc-up'
+    owner: 'root'
+    group: '{{ tinc_group }}'
+    mode: '0750'
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: (item.name|d() and item.tinc_options|d() and
+         (item.generate_tinc_up is undefined or item.generate_tinc_up|bool))
+
+- name: Generate tinc-down network scripts
+  template:
+    src: 'etc/tinc/network/tinc-down.j2'
+    dest: '/etc/tinc/{{ item.name }}/tinc-down'
+    owner: 'root'
+    group: '{{ tinc_group }}'
+    mode: '0750'
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: (item.name|d() and item.tinc_options|d() and
+         (item.generate_tinc_down is undefined or item.generate_tinc_down|bool))
+
+- name: Configure which networks are started at boot
+  template:
+    src: 'etc/tinc/nets.boot.j2'
+    dest: '/etc/tinc/nets.boot'
     owner: 'root'
     group: 'root'
-    mode: '0750'
-  with_dict: tinc_scripts
-  notify: [ 'Reload tinc configuration' ]
-  when: item.key is defined and item.key
+    mode: '0644'
 
 - name: Initialize RSA key pairs
-  shell: yes | tincd -n {{ tinc_network }} -K{{ tinc_rsa_key_length }}
+  shell: yes | tincd -n {{ item.name }} -K{{ item.rsa_key_length | d(tinc_rsa_key_length) }}
   args:
-    creates: '/etc/tinc/{{ tinc_network }}/rsa_key.priv'
+    creates: '/etc/tinc/{{ item.name }}/rsa_key.priv'
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name is defined and item.tinc_options is defined
 
 - name: Create persistent copy of host public key
-  command: cp /etc/tinc/{{ tinc_network }}/hosts/{{ tinc_hostname | replace("-","_") }}
-              /etc/tinc/{{ tinc_network }}/hosts/{{ tinc_hostname | replace("-","_") + ".d/99_rsa-public-key" }}
+  command: cp /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}
+              /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") + ".d/99_rsa-public-key" }}
   args:
-    creates: /etc/tinc/{{ tinc_network }}/hosts/{{ tinc_hostname | replace("-","_") + ".d/99_rsa-public-key" }}
+    creates: /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") + ".d/99_rsa-public-key" }}
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name is defined and item.tinc_options is defined
 
 - name: Generate host configuration file
   template:
     src: 'etc/tinc/network/hosts/hostname.j2'
-    dest: '/etc/tinc/{{ tinc_network }}/hosts/{{ tinc_hostname | replace("-","_") }}.d/00_host-config'
+    dest: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}.d/00_host-config'
     owner: 'root'
     group: 'root'
-    mode: '0644'
+    mode: '0640'
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name is defined and item.tinc_options is defined
 
 - name: Assemble host configuration file from parts
   assemble:
-    src: '/etc/tinc/{{ tinc_network }}/hosts/{{ tinc_hostname | replace("-","_") }}.d'
-    dest: '/etc/tinc/{{ tinc_network }}/hosts/{{ tinc_hostname | replace("-","_") }}'
+    src: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}.d'
+    dest: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}'
     owner: 'root'
     group: '{{ tinc_group }}'
     mode: '0640'
-  notify: [ 'Reload tinc configuration' ]
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name is defined and item.tinc_options is defined
+  notify: [ 'Reload tinc' ]
 
-- name: Read host configuration file into a variable
-  slurp:
-    src: '/etc/tinc/{{ tinc_network }}/hosts/{{ tinc_hostname | replace("-","_") }}'
-  register: tinc_register_host_config
+- name: Upload public keys from hosts
+  fetch:
+    src: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}'
+    dest: '{{ secret + "/tinc/networks/" + item.name + "/by-network/" + item.name + "/hosts/" + (item.hostname | d(tinc_hostname) | replace("-","_")) }}'
+    flat: True
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name|d() and item.tinc_options|d()
 
-- name: Redistribute configuration of internal hosts
+- name: Download public keys per network
   copy:
-    content: '{{ hostvars[inventory_hostname]["tinc_register_host_config"].content | b64decode }}'
-    dest: '/etc/tinc/{{ tinc_network }}/hosts/{{ hostvars[inventory_hostname]["tinc_register_host_config"].source | basename | replace("-","_") }}'
+    src: '{{ secret + "/tinc/networks/" + item.name + "/by-network/" + item.name + "/hosts/" }}'
+    dest: '/etc/tinc/{{ item.name }}/hosts/'
     owner: 'root'
     group: '{{ tinc_group }}'
     mode: '0640'
-  with_items: tinc_inventory_hosts
-  delegate_to: '{{ item }}'
-  when: item is defined and item != inventory_hostname and
-        hostvars[item].tinc_register_host_config is defined
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name is defined and item.tinc_options is defined
+  notify: [ 'Reload tinc' ]
 
-- name: Add configuration of external hosts
+- name: Download public keys for all hosts
   copy:
-    content: '{{ item.value }}'
-    dest: '/etc/tinc/{{ tinc_network }}/hosts/{{ item.key | replace("-","_") }}'
+    src: '{{ secret + "/tinc/networks/" + item.name + "/by-group/all/hosts/" }}'
+    dest: '/etc/tinc/{{ item.name }}/hosts/'
     owner: 'root'
     group: '{{ tinc_group }}'
     mode: '0640'
-  with_dict: tinc_external_hosts
-  when: tinc_external_hosts is defined and tinc_external_hosts
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name is defined and item.tinc_options is defined
+  notify: [ 'Reload tinc' ]
 
-- name: install the systemd unit file
+- name: Download public keys per group
+  copy:
+    src: '{{ secret + "/tinc/networks/" + item.0.name + "/by-group/" + item.1 + "/hosts/" }}'
+    dest: '/etc/tinc/{{ item.0.name }}/hosts/'
+    owner: 'root'
+    group: '{{ tinc_group }}'
+    mode: '0640'
+  with_nested:
+    - '{{ tinc_default_networks + tinc_networks }}'
+    - '{{ tinc_inventory_groups }}'
+  when: (item.0.name|d() and item.0.tinc_options|d() and
+         item.1 in group_names)
+  notify: [ 'Reload tinc' ]
+
+- name: Download public keys per host
+  copy:
+    src: '{{ secret + "/tinc/networks/" + item.name + "/by-host/" + ((item.hostname | d(tinc_hostname)) | replace("-","_")) + "/hosts/" }}'
+    dest: '/etc/tinc/{{ item.name }}/hosts/'
+    owner: 'root'
+    group: '{{ tinc_group }}'
+    mode: '0640'
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: item.name|d() and item.tinc_options|d()
+  notify: [ 'Reload tinc' ]
+
+- name: Configure systemd default variables
   template:
-    src: 'etc/systemd/system/tinc@.service.j2'
-    dest: '/etc/systemd/system/tinc@.service'
+    src: 'etc/default/tinc-network.j2'
+    dest: '/etc/default/tinc-{{ item.name }}'
     owner: 'root'
     group: 'root'
     mode: '0644'
-  when: ansible_local|d() and (ansible_local.init is undefined or
-        ansible_local.init in [ 'systemd' ])
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: tinc_systemd|bool and item.name|d() and item.tinc_options|d()
+  notify: [ 'Reload tinc' ]
 
-- name: register autostart tinc service systemd
+- name: Configure systemd unit files
+  template:
+    src: 'etc/systemd/system/{{ item }}.j2'
+    dest: '/etc/systemd/system/{{ item }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  with_items: [ 'tinc.service', 'tinc@.service' ]
+  register: tinc_register_systemd
+  when: tinc_systemd | bool
+
+- name: Reload systemd daemon configuration
+  shell: systemctl daemon-reload ; systemctl enable tinc.service
+  when: tinc_register_systemd.changed | bool
+
+- name: Start tinc VPN networks on first install
   service:
-    name: 'tinc@{{ tinc_network }}'
-    enabled: 'yes'
-    state: 'started'
-  notify: [ 'Restart tinc VPN connection' ]
-  when: ansible_local|d() and (ansible_local.init is undefined or
-        ansible_local.init in [ 'systemd' ])
+    name: 'tinc'
+    state: 'restarted'
+  when: not tinc_systemd | bool and tinc_register_install.changed | bool
 
-- name: Start VPN interface if required
-  shell: test ! -x /tmp/ifupdown-delayed-{{ tinc_interface }} || /tmp/ifupdown-delayed-{{ tinc_interface }} {{ tinc_interface_auto | bool | lower }}
-  changed_when: False
+- name: Manage tinc network services in systemd
+  service:
+    name: 'tinc@{{ item.name }}'
+    enabled: '{{ (True if ((item.delete is undefined or not item.delete|bool) and
+                           (item.boot is undefined or item.boot|bool))
+                       else False) | bool }}'
+    state: '{{ ("stopped" if (item.delete|d() and item.delete|bool) else "started") }}'
+  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  when: tinc_systemd | bool and item.name|d() and item.tinc_options|d()
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,24 +6,24 @@
     state: 'present'
     install_recommends: False
   with_flattened:
-    - '{{ tinc_base_packages }}'
-    - '{{ tinc_packages }}'
-  register: tinc_register_install
+    - '{{ tinc__base_packages }}'
+    - '{{ tinc__packages }}'
+  register: tinc__register_install
 
 - name: Create system group for VPN service
   group:
-    name: '{{ tinc_group }}'
+    name: '{{ tinc__group }}'
     state: 'present'
     system: True
 
 - name: Create system user for VPN service
   user:
-    name: '{{ tinc_user }}'
+    name: '{{ tinc__user }}'
     state: 'present'
     system: True
     comment: 'tinc VPN service'
-    home: '{{ tinc_home }}'
-    group: '{{ tinc_group }}'
+    home: '{{ tinc__home }}'
+    group: '{{ tinc__group }}'
     shell: '/bin/false'
     createhome: False
 
@@ -31,8 +31,8 @@
   modprobe:
     name: '{{ item }}'
     state: 'present'
-  with_items: '{{ tinc_modprobe_modules }}'
-  when: (tinc_modprobe|bool and ansible_local|d() and ansible_local.cap12s|d() and
+  with_items: '{{ tinc__modprobe_modules }}'
+  when: (tinc__modprobe|bool and ansible_local|d() and ansible_local.cap12s|d() and
          (not ansible_local.cap12s.enabled | bool or
           (ansible_local.cap12s.enabled | bool and
            'cap_sys_admin' in ansible_local.cap12s.list)))
@@ -43,8 +43,8 @@
     regexp: '^{{ item }}$'
     line: '{{ item }}'
     state: 'present'
-  with_items: '{{ tinc_modprobe_modules }}'
-  when: (tinc_modprobe|bool and ansible_local|d() and ansible_local.cap12s|d() and
+  with_items: '{{ tinc__modprobe_modules }}'
+  when: (tinc__modprobe|bool and ansible_local|d() and ansible_local.cap12s|d() and
          (not ansible_local.cap12s.enabled | bool or
           (ansible_local.cap12s.enabled | bool and
            'cap_sys_admin' in ansible_local.cap12s.list)))
@@ -60,12 +60,12 @@
 
 - name: Create required directories
   file:
-    path: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}.d'
+    path: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc__hostname)) | replace("-","_") }}.d'
     state: 'directory'
     owner: 'root'
     group: 'root'
     mode: '0755'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name|d()
 
 - name: Generate main configuration file
@@ -75,7 +75,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name|d() and item.tinc_options|d()
   notify: [ 'Reload tinc' ]
 
@@ -84,9 +84,9 @@
     src: 'etc/tinc/network/tinc-up.j2'
     dest: '/etc/tinc/{{ item.name }}/tinc-up'
     owner: 'root'
-    group: '{{ tinc_group }}'
+    group: '{{ tinc__group }}'
     mode: '0750'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: (item.name|d() and item.tinc_options|d() and
          (item.generate_tinc_up is undefined or item.generate_tinc_up|bool))
 
@@ -95,9 +95,9 @@
     src: 'etc/tinc/network/tinc-down.j2'
     dest: '/etc/tinc/{{ item.name }}/tinc-down'
     owner: 'root'
-    group: '{{ tinc_group }}'
+    group: '{{ tinc__group }}'
     mode: '0750'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: (item.name|d() and item.tinc_options|d() and
          (item.generate_tinc_down is undefined or item.generate_tinc_down|bool))
 
@@ -110,47 +110,47 @@
     mode: '0644'
 
 - name: Initialize RSA key pairs
-  shell: yes | tincd -n {{ item.name }} -K{{ item.rsa_key_length | d(tinc_rsa_key_length) }}
+  shell: yes | tincd -n {{ item.name }} -K{{ item.rsa_key_length | d(tinc__rsa_key_length) }}
   args:
     creates: '/etc/tinc/{{ item.name }}/rsa_key.priv'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name is defined and item.tinc_options is defined
 
 - name: Create persistent copy of host public key
-  command: cp /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}
-              /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") + ".d/99_rsa-public-key" }}
+  command: cp /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc__hostname)) | replace("-","_") }}
+              /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc__hostname)) | replace("-","_") + ".d/99_rsa-public-key" }}
   args:
-    creates: /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") + ".d/99_rsa-public-key" }}
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+    creates: /etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc__hostname)) | replace("-","_") + ".d/99_rsa-public-key" }}
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name is defined and item.tinc_options is defined
 
 - name: Generate host configuration file
   template:
     src: 'etc/tinc/network/hosts/hostname.j2'
-    dest: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}.d/00_host-config'
+    dest: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc__hostname)) | replace("-","_") }}.d/00_host-config'
     owner: 'root'
     group: 'root'
     mode: '0640'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name is defined and item.tinc_options is defined
 
 - name: Assemble host configuration file from parts
   assemble:
-    src: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}.d'
-    dest: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}'
+    src: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc__hostname)) | replace("-","_") }}.d'
+    dest: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc__hostname)) | replace("-","_") }}'
     owner: 'root'
-    group: '{{ tinc_group }}'
+    group: '{{ tinc__group }}'
     mode: '0640'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name is defined and item.tinc_options is defined
   notify: [ 'Reload tinc' ]
 
 - name: Upload public keys from hosts
   fetch:
-    src: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}'
-    dest: '{{ secret + "/tinc/networks/" + item.name + "/by-network/" + item.name + "/hosts/" + (item.hostname | d(tinc_hostname) | replace("-","_")) }}'
+    src: '/etc/tinc/{{ item.name }}/hosts/{{ (item.hostname | d(tinc__hostname)) | replace("-","_") }}'
+    dest: '{{ secret + "/tinc/networks/" + item.name + "/by-network/" + item.name + "/hosts/" + (item.hostname | d(tinc__hostname) | replace("-","_")) }}'
     flat: True
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name|d() and item.tinc_options|d()
 
 - name: Download public keys per network
@@ -158,9 +158,9 @@
     src: '{{ secret + "/tinc/networks/" + item.name + "/by-network/" + item.name + "/hosts/" }}'
     dest: '/etc/tinc/{{ item.name }}/hosts/'
     owner: 'root'
-    group: '{{ tinc_group }}'
+    group: '{{ tinc__group }}'
     mode: '0640'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name is defined and item.tinc_options is defined
   notify: [ 'Reload tinc' ]
 
@@ -169,9 +169,9 @@
     src: '{{ secret + "/tinc/networks/" + item.name + "/by-group/all/hosts/" }}'
     dest: '/etc/tinc/{{ item.name }}/hosts/'
     owner: 'root'
-    group: '{{ tinc_group }}'
+    group: '{{ tinc__group }}'
     mode: '0640'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name is defined and item.tinc_options is defined
   notify: [ 'Reload tinc' ]
 
@@ -180,23 +180,23 @@
     src: '{{ secret + "/tinc/networks/" + item.0.name + "/by-group/" + item.1 + "/hosts/" }}'
     dest: '/etc/tinc/{{ item.0.name }}/hosts/'
     owner: 'root'
-    group: '{{ tinc_group }}'
+    group: '{{ tinc__group }}'
     mode: '0640'
   with_nested:
-    - '{{ tinc_default_networks + tinc_networks }}'
-    - '{{ tinc_inventory_groups }}'
+    - '{{ tinc__default_networks + tinc__networks }}'
+    - '{{ tinc__inventory_groups }}'
   when: (item.0.name|d() and item.0.tinc_options|d() and
          item.1 in group_names)
   notify: [ 'Reload tinc' ]
 
 - name: Download public keys per host
   copy:
-    src: '{{ secret + "/tinc/networks/" + item.name + "/by-host/" + ((item.hostname | d(tinc_hostname))) + "/hosts/" }}'
+    src: '{{ secret + "/tinc/networks/" + item.name + "/by-host/" + ((item.hostname | d(tinc__hostname))) + "/hosts/" }}'
     dest: '/etc/tinc/{{ item.name }}/hosts/'
     owner: 'root'
-    group: '{{ tinc_group }}'
+    group: '{{ tinc__group }}'
     mode: '0640'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
   when: item.name|d() and item.tinc_options|d()
   notify: [ 'Reload tinc' ]
 
@@ -207,8 +207,8 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
-  when: tinc_systemd|bool and item.name|d() and item.tinc_options|d()
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
+  when: tinc__systemd|bool and item.name|d() and item.tinc_options|d()
   notify: [ 'Reload tinc' ]
 
 - name: Configure systemd unit files
@@ -219,18 +219,18 @@
     group: 'root'
     mode: '0644'
   with_items: [ 'tinc.service', 'tinc@.service' ]
-  register: tinc_register_systemd
-  when: tinc_systemd | bool
+  register: tinc__register_systemd
+  when: tinc__systemd | bool
 
 - name: Reload systemd daemon configuration
   shell: systemctl daemon-reload ; systemctl enable tinc.service
-  when: tinc_register_systemd.changed | bool
+  when: tinc__register_systemd.changed | bool
 
 - name: Start tinc VPN networks on first install
   service:
     name: 'tinc'
     state: 'restarted'
-  when: not tinc_systemd | bool and tinc_register_install.changed | bool
+  when: not tinc__systemd | bool and tinc__register_install.changed | bool
 
 - name: Manage tinc network services in systemd
   service:
@@ -239,6 +239,6 @@
                            (item.boot is undefined or item.boot|bool))
                        else False) | bool }}'
     state: '{{ ("stopped" if (item.delete|d() and item.delete|bool) else "started") }}'
-  with_items: '{{ tinc_default_networks + tinc_networks }}'
-  when: tinc_systemd | bool and item.name|d() and item.tinc_options|d()
+  with_items: '{{ tinc__default_networks + tinc__networks }}'
+  when: tinc__systemd | bool and item.name|d() and item.tinc_options|d()
 

--- a/templates/etc/default/tinc-network.j2
+++ b/templates/etc/default/tinc-network.j2
@@ -1,0 +1,18 @@
+# {{ ansible_managed }}
+
+{% set tinc__tpl_options = [] %}
+{% if item.interface|d() %}
+{%   set _ = tinc__tpl_options.append("-o Interface=" + item.interface) %}
+{% endif %}
+{% if item.mlock | bool %}
+{%   set _ = tinc__tpl_options.append("--mlock") %}
+{% endif %}
+{% if item.chroot | bool %}
+{%   set _ = tinc__tpl_options.append("--chroot") %}
+{% endif %}
+{% if item.user|d() %}
+{%   set _ = tinc__tpl_options.append("--user=" + item.user) %}
+{% endif %}
+# Configuration for {{ item.name }} tinc network
+TINC_NETWORK_OPTIONS="{{ tinc__tpl_options | join(' ') }}"
+

--- a/templates/etc/default/tinc.j2
+++ b/templates/etc/default/tinc.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # Extra options to be passed to tincd.
-{% if tinc_extra_options == '' %}# EXTRA="-d" {% else %}EXTRA="{{ tinc_extra_options }}"{% endif %}
+EXTRA="{{ tinc_extra_options }}"
 
 # Limits to be configured for the tincd process. Please read your shell
 # (pointed by /bin/sh) documentation for ulimit. You probably want to raise the

--- a/templates/etc/default/tinc.j2
+++ b/templates/etc/default/tinc.j2
@@ -1,9 +1,9 @@
 # {{ ansible_managed }}
 
 # Extra options to be passed to tincd.
-EXTRA="{{ tinc_extra_options }}"
+EXTRA="{{ tinc__extra_options }}"
 
 # Limits to be configured for the tincd process. Please read your shell
 # (pointed by /bin/sh) documentation for ulimit. You probably want to raise the
 # max locked memory value if using both --mlock and --user flags.
-LIMITS="{{ tinc_ulimit_options | default('-l 1024') }}"
+LIMITS="{{ tinc__ulimit_options | default('-l 1024') }}"

--- a/templates/etc/systemd/system/tinc.service.j2
+++ b/templates/etc/systemd/system/tinc.service.j2
@@ -1,0 +1,23 @@
+# {{ ansible_managed }}
+
+# This is a mostly empty service, but allows commands like stop, start, reload
+# to propagate to all tinc@ service instances.
+
+[Unit]
+Description=Tinc VPN
+Documentation=man:tinc(8) man:tinc.conf(5)
+Documentation=http://tinc-vpn.org/docs/
+After=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+ExecReload=/bin/true
+ExecStop=/bin/true
+WorkingDirectory=/etc/tinc
+
+[Install]
+WantedBy=network.target
+

--- a/templates/etc/systemd/system/tinc@.service.j2
+++ b/templates/etc/systemd/system/tinc@.service.j2
@@ -1,17 +1,23 @@
 #{{ ansible_managed }}
+
 [Unit]
-Description=tinc for network %I
-After=local-fs.target network-pre.target networking.service
-Before=network.target
+Description=Tinc VPN for %i network
+Documentation=man:tincd(8) man:tinc.conf(5)
+Documentation=http://tinc-vpn.org/docs/
+PartOf=tinc.service
+ReloadPropagatedFrom=tinc.service
 
 [Service]
 Type=simple
-ExecStart=/usr/sbin/tincd -D -n %i -o Interface=%i --mlock --chroot --user={{ tinc_user }}
-ExecReload=/usr/sbin/tincd -n %i reload
-ExecStop=/usr/sbin/tincd -n %i stop
-TimeoutStopSec=5
-Restart=always
-RestartSec=60
+WorkingDirectory=/etc/tinc/%i
+EnvironmentFile=-/etc/default/tinc
+EnvironmentFile=-/etc/default/tinc-%i
+ExecStart=/usr/sbin/tincd --net %i --no-detach $EXTRA $TINC_NETWORK_OPTIONS
+ExecReload=/usr/sbin/tincd --net %i --kill=HUP
+ExecStop=/usr/sbin/tincd --net %i --kill
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=tinc.service

--- a/templates/etc/tinc/nets.boot.j2
+++ b/templates/etc/tinc/nets.boot.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+
+## This file contains all names of the networks to be started on system startup.
+
+{% for item in (tinc_default_networks + tinc_networks) %}
+{%   if (item.name|d() and item.tinc_options|d() and
+         (item.state is undefined or item.state != "absent") and
+         (item.boot is undefined or item.boot|bool)) %}
+{{ item.name }}
+{%   endif %}
+{% endfor %}

--- a/templates/etc/tinc/nets.boot.j2
+++ b/templates/etc/tinc/nets.boot.j2
@@ -2,7 +2,7 @@
 
 ## This file contains all names of the networks to be started on system startup.
 
-{% for item in (tinc_default_networks + tinc_networks) %}
+{% for item in (tinc__default_networks + tinc__networks) %}
 {%   if (item.name|d() and item.tinc_options|d() and
          (item.state is undefined or item.state != "absent") and
          (item.boot is undefined or item.boot|bool)) %}

--- a/templates/etc/tinc/network/hosts/hostname.j2
+++ b/templates/etc/tinc/network/hosts/hostname.j2
@@ -1,26 +1,26 @@
 # {{ ansible_managed }}
 
 {% set tinc_tpl_host_keys_seen = [] %}
-{% if tinc_host_configuration is defined and tinc_host_configuration %}
-{% for key, value in tinc_host_configuration.iteritems() %}
-{% if key | lower not in [ '{{ tinc_hostname | replace("-","_") }}-up', '{{ tinc_hostname | replace("-","_") }}-down', 'host-up', 'host-down' ] %}
-{% if key not in tinc_tpl_host_keys_seen %}
-{% if value is string %}
+{% if item.tinc_host_options|d() %}
+{%   for key, value in item.tinc_host_options.iteritems() %}
+{%     if key | lower not in [ '{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}-up', '{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}-down', 'host-up', 'host-down' ] %}
+{%       if key not in tinc_tpl_host_keys_seen %}
+{%         if value is string %}
 {{ key }} = {{ value }}
-{% else %}
-{% for element in value %}
+{%         else %}
+{%           for element in value %}
 {{ key }} = {{ element }}
-{% endfor %}
-{% endif %}
-{% set _ = tinc_tpl_host_keys_seen.append(key) %}
-{% endif %}
-{% endif %}
-{% endfor %}
+{%           endfor %}
+{%         endif %}
+{%         set _ = tinc_tpl_host_keys_seen.append(key) %}
+{%       endif %}
+{%     endif %}
+{%   endfor %}
 {% endif %}
 {% if (('Address' not in tinc_tpl_host_keys_seen) or ('address' not in tinc_tpl_host_keys_seen)) %}
-{% for address in (tinc_addresses|d([]) + ansible_all_ipv4_addresses|d([]) + ansible_all_ipv6_addresses|d([])) %}
-{% if address | ipaddr('public') %}
-Address = {{ address }} {{ tinc_host_port }}
-{% endif %}
-{% endfor %}
+{%   for address in (item.tinc_addresses|d([]) + tinc_host_addresses|d([])) %}
+{%     if address %}
+Address = {{ address }} {{ item.tinc_options.Port if item.tinc_options.Port|d() else item.port }}
+{%     endif %}
+{%   endfor %}
 {% endif %}

--- a/templates/etc/tinc/network/hosts/hostname.j2
+++ b/templates/etc/tinc/network/hosts/hostname.j2
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
 
-{% set tinc_tpl_host_keys_seen = [] %}
+{% set tinc__tpl_host_keys_seen = [] %}
 {% if item.tinc_host_options|d() %}
 {%   for key, value in item.tinc_host_options.iteritems() %}
-{%     if key | lower not in [ '{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}-up', '{{ (item.hostname | d(tinc_hostname)) | replace("-","_") }}-down', 'host-up', 'host-down' ] %}
-{%       if key not in tinc_tpl_host_keys_seen %}
+{%     if key | lower not in [ '{{ (item.hostname | d(tinc__hostname)) | replace("-","_") }}-up', '{{ (item.hostname | d(tinc__hostname)) | replace("-","_") }}-down', 'host-up', 'host-down' ] %}
+{%       if key not in tinc__tpl_host_keys_seen %}
 {%         if value is string %}
 {{ key }} = {{ value }}
 {%         else %}
@@ -12,13 +12,13 @@
 {{ key }} = {{ element }}
 {%           endfor %}
 {%         endif %}
-{%         set _ = tinc_tpl_host_keys_seen.append(key) %}
+{%         set _ = tinc__tpl_host_keys_seen.append(key) %}
 {%       endif %}
 {%     endif %}
 {%   endfor %}
 {% endif %}
-{% if (('Address' not in tinc_tpl_host_keys_seen) or ('address' not in tinc_tpl_host_keys_seen)) %}
-{%   for address in (item.tinc_addresses|d([]) + tinc_host_addresses|d([])) %}
+{% if (('Address' not in tinc__tpl_host_keys_seen) or ('address' not in tinc__tpl_host_keys_seen)) %}
+{%   for address in (item.tinc_addresses|d([]) + tinc__host_addresses|d([])) %}
 {%     if address %}
 Address = {{ address }} {{ item.tinc_options.Port if item.tinc_options.Port|d() else item.port }}
 {%     endif %}

--- a/templates/etc/tinc/network/tinc-down.j2
+++ b/templates/etc/tinc/network/tinc-down.j2
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+
+{% if item.tinc_down is undefined %}
+{%   if item.link_type|d() %}
+{%     if item.link_type == 'static' %}
+{%       if item.bridge|d() %}
+tinc_bridge="{{ item.bridge }}"
+if [ -d /sys/class/net/${tinc_bridge}/bridge ] ; then
+    brctl delif ${tinc_bridge} ${INTERFACE}
+fi
+
+{%       endif %}
+ip addr del {{ item.interface_ip | d('0.0.0.0') }} dev ${INTERFACE}
+ip link set ${INTERFACE} down
+{%     endif %}
+{%   else %}
+{%     if ((item.dhclient is undefined or item.dhclient|bool) and
+           item.tinc_options|d() and item.tinc_options.Mode|d() and item.tinc_options.Mode == 'switch') %}
+dhclient -r -v -pf /run/dhclient.${INTERFACE}.pid \
+         -lf /var/lib/dhcp/dhclient.${INTERFACE}.leases
+{%     endif %}
+{%   endif %}
+{% else %}
+{{ item.tinc_down }}
+{% endif %}

--- a/templates/etc/tinc/network/tinc-script.j2
+++ b/templates/etc/tinc/network/tinc-script.j2
@@ -1,3 +1,0 @@
-{% if item.value is defined and item.value %}
-{{ item.value }}
-{% endif %}

--- a/templates/etc/tinc/network/tinc-up.j2
+++ b/templates/etc/tinc/network/tinc-up.j2
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+
+{% if item.tinc_up is undefined %}
+{%   if item.hwaddr is undefined or not item.hwaddr %}
+# Create random but predictable MAC address
+hwaddr=$(echo "$(hostname -f)${INTERFACE}" | md5sum | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/{{ item.hwaddr_prefix|d(tinc_hwaddr_prefix) }}:\1:\2:\3:\4:\5/')
+{%   endif %}
+{%   if item.hwaddr|d() and item.hwaddr == "*" %}
+ip link set dev ${INTERFACE}  up
+{%   else %}
+ip link set dev ${INTERFACE} address {{ item.hwaddr if item.hwaddr|d() else '${hwaddr}' }} up
+{% endif %}
+
+{%   if item.link_type|d() %}
+{%     if item.link_type == 'static' %}
+ip addr add {{ item.interface_ipv4 | d('0.0.0.0') }} dev ${INTERFACE}
+
+{%       if item.bridge|d() %}
+tinc_bridge="{{ item.bridge }}"
+if [ -d /sys/class/net/${tinc_bridge}/bridge ] ; then
+    brctl addif ${tinc_bridge} ${INTERFACE}
+fi
+
+{%       endif %}
+{%     endif %}
+{%   else %}
+{%     if ((item.dhclient is undefined or item.dhclient|bool) and
+           item.tinc_options|d() and item.tinc_options.Mode|d() and item.tinc_options.Mode == 'switch') %}
+dhclient -v -pf /run/dhclient.${INTERFACE}.pid \
+         -lf /var/lib/dhcp/dhclient.${INTERFACE}.leases \
+         ${INTERFACE} &
+{%     endif %}
+{%   endif %}
+{% else %}
+{{ item.tinc_up }}
+{% endif %}

--- a/templates/etc/tinc/network/tinc-up.j2
+++ b/templates/etc/tinc/network/tinc-up.j2
@@ -5,7 +5,7 @@
 {% if item.tinc_up is undefined %}
 {%   if item.hwaddr is undefined or not item.hwaddr %}
 # Create random but predictable MAC address
-hwaddr=$(echo "$(hostname -f)${INTERFACE}" | md5sum | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/{{ item.hwaddr_prefix|d(tinc_hwaddr_prefix) }}:\1:\2:\3:\4:\5/')
+hwaddr=$(echo "$(hostname -f)${INTERFACE}" | md5sum | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/{{ item.hwaddr_prefix|d(tinc__hwaddr_prefix) }}:\1:\2:\3:\4:\5/')
 {%   endif %}
 {%   if item.hwaddr|d() and item.hwaddr == "*" %}
 ip link set dev ${INTERFACE}  up

--- a/templates/etc/tinc/network/tinc.conf.j2
+++ b/templates/etc/tinc/network/tinc.conf.j2
@@ -7,7 +7,7 @@ Name = {{ item.hostname | replace("-","_") }}
 {%   elif item.tinc_options.Name|d() %}
 Name = {{ item.tinc_options.Name | replace("-","_") }}
 {%   else %}
-Name = $HOST
+Name = {{ tinc_hostname | replace("-","_") }}
 {%   endif %}
 {%   if item.port|d() %}
 Port = {{ item.port }}

--- a/templates/etc/tinc/network/tinc.conf.j2
+++ b/templates/etc/tinc/network/tinc.conf.j2
@@ -1,70 +1,40 @@
 # {{ ansible_managed }}
 
-{% set tinc_tpl_daemon_keys_seen = [] %}
-{% if tinc_hostname is defined and tinc_hostname %}
-Name = {{ tinc_hostname | replace("-","_") }}
-{% else %}
+{% set tinc_tpl_seen_keys = [ 'name', 'tinc-up', 'tinc-down', 'host-up', 'host-down', 'subnet-up', 'subnet-down' ] %}
+{% if item.tinc_options|d() %}
+{%   if item.hostname|d() %}
+Name = {{ item.hostname | replace("-","_") }}
+{%   elif item.tinc_options.Name|d() %}
+Name = {{ item.tinc_options.Name | replace("-","_") }}
+{%   else %}
 Name = $HOST
-{% endif %}
-{% for key, value in tinc_configuration.iteritems() %}
-{% if key | lower not in [ 'name', 'tinc-up', 'tinc-down', 'host-up', 'host-down', 'subnet-up', 'subnet-down' ] %}
-{% if key in tinc_daemon_configuration.keys() %}
-{% if tinc_daemon_configuration[key] is string %}
-{% if key | lower in [ 'connectto' ] %}
-{{ key }} = {{ tinc_daemon_configuration[key] | replace("-","_") }}
-{% else %}
-{{ key }} = {{ tinc_daemon_configuration[key] }}
-{% endif %}
-{% else %}
-{% for element in tinc_daemon_configuration[key] %}
-{% if key | lower in [ 'connectto' ] %}
-{{ key }} = {{ element | replace("-","_") }}
-{% else %}
-{{ key }} = {{ element }}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% set _ = tinc_tpl_daemon_keys_seen.append(key) %}
-{% else %}
-{% if value is string %}
-{% if key | lower in [ 'connectto' ] %}
+{%   endif %}
+{%   if item.port|d() %}
+Port = {{ item.port }}
+{%     set _ = tinc_tpl_seen_keys.append('port') %}
+{%   endif %}
+{%   if item.interface|d() %}
+Interface = {{ item.interface }}
+{%     set _ = tinc_tpl_seen_keys.append('interface') %}
+{%   endif %}
+{%   for key, value in item.tinc_options.iteritems() %}
+{%     if key | lower not in tinc_tpl_seen_keys %}
+{%       if value is string %}
+{%         if key | lower in [ 'connectto' ] %}
 {{ key }} = {{ value | replace("-","_") }}
-{% else %}
+{%         else %}
 {{ key }} = {{ value }}
-{% endif %}
-{% else %}
-{% for element in value %}
-{% if key | lower in [ 'connectto' ] %}
+{%         endif %}
+{%       else %}
+{%         for element in value %}
+{%           if key | lower in [ 'connectto' ] %}
 {{ key }} = {{ element | replace("-","_") }}
-{% else %}
+{%           else %}
 {{ key }} = {{ element }}
+{%           endif %}
+{%         endfor %}
+{%       endif %}
+{%     endif %}
+{%   endfor %}
 {% endif %}
-{% endfor %}
-{% endif %}
-{% set _ = tinc_tpl_daemon_keys_seen.append(key) %}
-{% endif %}
-{% endif %}
-{% endfor %}
-{% for key, value in tinc_daemon_configuration.iteritems() %}
-{% if key | lower not in [ 'name', 'tinc-up', 'tinc-down', 'host-up', 'host-down', 'subnet-up', 'subnet-down' ] %}
-{% if key not in tinc_tpl_daemon_keys_seen %}
-{% if value is string %}
-{% if key | lower in [ 'connectto' ] %}
-{{ key }} = {{ value | replace("-","_") }}
-{% else %}
-{{ key }} = {{ value }}
-{% endif %}
-{% else %}
-{% for element in value %}
-{% if key | lower in [ 'connectto' ] %}
-{{ key }} = {{ element | replace("-","_") }}
-{% else %}
-{{ key }} = {{ element }}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% set _ = tinc_tpl_daemon_keys_seen.append(key) %}
-{% endif %}
-{% endif %}
-{% endfor %}
 

--- a/templates/etc/tinc/network/tinc.conf.j2
+++ b/templates/etc/tinc/network/tinc.conf.j2
@@ -1,24 +1,24 @@
 # {{ ansible_managed }}
 
-{% set tinc_tpl_seen_keys = [ 'name', 'tinc-up', 'tinc-down', 'host-up', 'host-down', 'subnet-up', 'subnet-down' ] %}
+{% set tinc__tpl_seen_keys = [ 'name', 'tinc-up', 'tinc-down', 'host-up', 'host-down', 'subnet-up', 'subnet-down' ] %}
 {% if item.tinc_options|d() %}
 {%   if item.hostname|d() %}
 Name = {{ item.hostname | replace("-","_") }}
 {%   elif item.tinc_options.Name|d() %}
 Name = {{ item.tinc_options.Name | replace("-","_") }}
 {%   else %}
-Name = {{ tinc_hostname | replace("-","_") }}
+Name = {{ tinc__hostname | replace("-","_") }}
 {%   endif %}
 {%   if item.port|d() %}
 Port = {{ item.port }}
-{%     set _ = tinc_tpl_seen_keys.append('port') %}
+{%     set _ = tinc__tpl_seen_keys.append('port') %}
 {%   endif %}
 {%   if item.interface|d() %}
 Interface = {{ item.interface }}
-{%     set _ = tinc_tpl_seen_keys.append('interface') %}
+{%     set _ = tinc__tpl_seen_keys.append('interface') %}
 {%   endif %}
 {%   for key, value in item.tinc_options.iteritems() %}
-{%     if key | lower not in tinc_tpl_seen_keys %}
+{%     if key | lower not in tinc__tpl_seen_keys %}
 {%       if value is string %}
 {%         if key | lower in [ 'connectto' ] %}
 {{ key }} = {{ value | replace("-","_") }}


### PR DESCRIPTION
The role now supports management of multiple Tinc VPNs at the same time.
By default a 'mesh0' network is estabilished, which uses the Switch mode
and DHCP to manage network configuration.

The new role ddoesn't use 'ifupdown' configuration to manage the network
interfaces, instead custom 'tinc-up' and 'tinc-down' scripts take care
of setting up and tearing down the virtual Ethernet interface used by
the VPN.

If 'systemd' is detected on a host, role installs custom service units
that allow to manage each Tinc VPN separately from the others. The role
uses these units as needed to start/stop/restart the daemons.

Configuration for 'debops.etc_services', 'debops.ferm' and
'debops.secret' Ansible roles is generated dynamically by custom
templates. This requires a customized Ansible playbook (see the
documentation).

Public RSA host keys are not distributed using YAML text blocks.
Instead, 'debops.secret' role manages as set of directories which can be
used to deploy public keys to the hosts in the mesh.
